### PR TITLE
Add the `s` values which work for `k`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,13 @@ make -j 6
 ./ProofOfSpace -k 25 verify <hex proof> <32 byte hex challenge>
 ./ProofOfSpace -f "plot.dat" check <iterations>
 ```
+Following is the map of what least values of (`-s or --stripes`) work for value of (`-k or --size`).
+Note: `k` should be between `17` and `49` and `s` is a power of `2`.
+```bash
+k=18, s=2048
+k=19, s=1024
+k=20, s=2048
+```
 
 ### Benchmark
 

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -115,6 +115,10 @@ int main(int argc, char *argv[]) try {
     if (operation == "help") {
         HelpAndQuit(options);
     } else if (operation == "create") {
+        if (k < kMinPlotSize || k > kMaxPlotSize){
+          cout << "Invalid plot size(k), should be between " << kMinPlotSize << " and " << kMaxPlotSize << endl;
+          exit(1);
+        }
         cout << "Generating plot for k=" << static_cast<int>(k) << " filename=" << filename
              << " id=" << id << endl
              << endl;


### PR DESCRIPTION
Do error handling at start for invalid values of `k`.
Solves part of #10 