### PR TITLE
[Working]fix for static compilation for xenial issue (#7).

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,6 +135,14 @@ IF (BUILD_PROOF_OF_SPACE_STATICALLY)
   target_link_libraries(ProofOfSpace -static)
 ENDIF()
 
+option(BUILD_PROOF_OF_SPACE_WITH_GLIBC_2_23 "Build ProofOfSpace target statically" OFF)
+IF(BUILD_PROOF_OF_SPACE_WITH_GLIBC_2_23)
+  message("Statically build ProofOfSpace with custom glibc version")
+  set (GLIBC_2_23_PATH ${LD_LIBRARY_PATH})
+  set (CMAKE_EXE_LINKER_FLAGS "-Wl,--rpath=${GLIBC_2_23_PATH}")
+  message("GLIBC was picked from = " ${CMAKE_EXE_LINKER_FLAGS})
+ENDIF()
+
 add_executable(RunTests
     tests/test-main.cpp
     tests/test.cpp


### PR DESCRIPTION
Fix the compilation issue for linking with glibc for xenial.
To link to glibc based glibc, need to explicitly specify to the cmake using,
`-DBUILD_PROOF_OF_SPACE_WITH_GLIBC_2_23=ON` and specify the path to glibc using
`-DGLIBC_2_23_PATH=<path to glibc's lib folder>`

If the path is not set the default one is the `LD_LIBRARY_PATH`.
e.g usage
`cmake -DBUILD_PROOF_OF_SPACE_WITH_GLIBC_2_23=On -DGLIBC_2_23_PATH=~/old_glibc_build/glibc/build/install/lib ../chiapos/`